### PR TITLE
Added dollar sign and additional decimal place to currency display

### DIFF
--- a/docassemble/SmallClClaimAndAffidavit/data/questions/final__dc_84_affidavit_and_claim_sm.yml
+++ b/docassemble/SmallClClaimAndAffidavit/data/questions/final__dc_84_affidavit_and_claim_sm.yml
@@ -1001,6 +1001,8 @@ fields:
     field: amount
     datatype: currency
     max: 7000
+    min: 0
+    currency symbol: $
 under: ${ collapse_template(amount_explanation) }
 ---
 template: amount_explanation

--- a/docassemble/SmallClClaimAndAffidavit/data/questions/review.yml
+++ b/docassemble/SmallClClaimAndAffidavit/data/questions/review.yml
@@ -197,7 +197,7 @@ review:
     button: |-
       **How much money are you asking for?**
 
-      ${ amount }
+      ${ currency(amount, symbol=u'$') }
   - Edit: 
       - claim_for_damages
       - recompute:


### PR DESCRIPTION
- Fixed #89 by using `currency()` function with symbol parameter in review screen; also incorporated `min` and `currency_symbol` to the question configuration.