### PR TITLE
93 court info

### DIFF
--- a/docassemble/SmallClClaimAndAffidavit/data/questions/review.yml
+++ b/docassemble/SmallClClaimAndAffidavit/data/questions/review.yml
@@ -278,6 +278,9 @@ review:
       ${ word(yesno(directly_involved_transaction_or_dispute)) }
   - Edit: 
       - county_choice
+      - recompute:
+        - court_index
+        - the_court
     button: |-
       **In what county are you filing the case?**
 


### PR DESCRIPTION
- Fixed #93 by adding `court_index` and `the_court` to recompute list in `county_choice` review block.