### PR TITLE
Added variable to recompute list to re-trigger kickout

### DIFF
--- a/docassemble/SmallClClaimAndAffidavit/data/questions/final__dc_84_affidavit_and_claim_sm.yml
+++ b/docassemble/SmallClClaimAndAffidavit/data/questions/final__dc_84_affidavit_and_claim_sm.yml
@@ -304,6 +304,15 @@ code: |
   reset_cannot_file_case = True
 ---
 code: |
+  if five_small_claims_cases:
+    cannot_file_case
+
+    if not cannot_file_case:
+      cannot_file_case_kickout
+      
+  reask_cannot_file_case = True
+---
+code: |
   if not cannot_file_case:
     cannot_file_case_kickout
 

--- a/docassemble/SmallClClaimAndAffidavit/data/questions/review.yml
+++ b/docassemble/SmallClClaimAndAffidavit/data/questions/review.yml
@@ -255,6 +255,7 @@ review:
       - five_small_claims_cases
       - recompute:
         - reset_cannot_file_case
+        - reask_cannot_file_case
     button: |-
       **Have you filed five small claims cases in the past week?**
 


### PR DESCRIPTION
- Fixed #92 by adding new variable to recompute list in the `five_small_claims_cases` review block. If the user changes their answer to 'Yes', the variable triggers a code block that re-asks the `cannot_file_case` and (if the user answers 'No') immediately takes them to the kickout screen.