### PR TITLE
more work on review screen and related updates

### DIFF
--- a/docassemble/SmallClClaimAndAffidavit/data/questions/final__dc_84_affidavit_and_claim_sm.yml
+++ b/docassemble/SmallClClaimAndAffidavit/data/questions/final__dc_84_affidavit_and_claim_sm.yml
@@ -92,9 +92,6 @@ code: |
         fulltime_salaried_employee
         if not fulltime_salaried_employee:
             fulltime_salaried_employee_kick_out
-    
-      if Who_are_you_filing_claim_for == "Other":
-        other_plaintiff_kickout
   
   users[0].name.first
   users[0].address.address
@@ -214,46 +211,10 @@ code: |
   regather_owner_partner = True
 ---
 code: |
-  if (Who_are_you_filing_claim_for == "A sole proprietor (a business that is not a corporation, but is owned by one person)" \
-  or Who_are_you_filing_claim_for == "A partnership (a business that is not a corporation, but is owned by two or more people)"):
-    if not is_owner_or_partner:
-      fulltime_salaried_employee
-      if not fulltime_salaried_employee:
-        fulltime_salaried_employee_kick_out
-
-  if Who_are_you_filing_claim_for == "A corporation":
-    fulltime_salaried_employee
-    if not fulltime_salaried_employee:
-      fulltime_salaried_employee_kick_out
-      
-  regather_fulltime_employee = True
----
-code: |
   if Who_are_you_filing_claim_for != "Another person":
     undefine('has_court_appointed_you_as')
 
   reset_next_friend_appointment = True
----
-code: |
-  if (Who_are_you_filing_claim_for == "A sole proprietor (a business that is not a corporation, but is owned by one person)" \
-  or Who_are_you_filing_claim_for == "A partnership (a business that is not a corporation, but is owned by two or more people)") \
-  or Who_are_you_filing_claim_for == "A corporation":
-    if not fulltime_salaried_employee:
-      fulltime_salaried_employee_kick_out
-
-  review_employee_kickout = True
----
-code: |
-  if Who_are_you_filing_claim_for == "Other":
-    other_plaintiff_kickout
-
-  review_other_kickout = True
----
-code: |
-  if claims_suit_against_state:
-    claims_kick_out
-
-  review_state_claim_kickout = True
 ---
 code: |
   if not claim_against_local_government:
@@ -271,12 +232,6 @@ code: |
   reask_governmental_immunity = True
 ---
 code: |
-  if not governmental_immunity:
-    governmental_immunity_no
-
-  review_gov_immunity_kickout = True
----
-code: |
   if not five_small_claims_cases:
     undefine('cannot_file_case')
 
@@ -290,18 +245,6 @@ code: |
       cannot_file_case_kickout
       
   reask_cannot_file_case = True
----
-code: |
-  if not cannot_file_case:
-    cannot_file_case_kickout
-
-  review_wait_week_kickout = True
----
-code: |
-  if not directly_involved_transaction_or_dispute:
-    claims_kick_out
-
-  review_directly_involved_kickout = True
 ---
 code: |
   undefine('defendants[0].name.first')
@@ -535,18 +478,6 @@ subquestion: |
   % endif
   
   If you think you made a mistake, tap **Undo**. This will take you back to the previous screen and you can change your answer. Otherwise, tap the **Leave** button below to return to [Michigan Legal Help](https://michiganlegalhelp.org/).
-buttons:
-  - Leave: leave
-    url: https://michiganlegalhelp.org/
----
-id: other plaintiff kickout
-event: other_plaintiff_kickout
-question: |
-  You can't use this tool.
-subquestion: |
-  You can only use this tool to prepare small claims forms if you are filing the claim for yourself or for certain other people or businesses.
-  
-  If you think you made a mistake, tap **Undo** and change your answer. Otherwise, tap the **Leave** button below to return to [Michigan Legal Help](https://michiganlegalhelp.org/).
 buttons:
   - Leave: leave
     url: https://michiganlegalhelp.org/
@@ -1111,13 +1042,29 @@ fields:
 id: Who_are_you_filing_claim_for
 question: |
   Who are you filing this claim for?
-field: Who_are_you_filing_claim_for
-choices:
-  - Another person
-  - A sole proprietor (a business that is not a corporation, but is owned by one person)
-  - A partnership (a business that is not a corporation, but is owned by two or more people)
-  - A corporation
-  - Other
+fields: 
+  - no label: Who_are_you_filing_claim_for
+    datatype: radio
+    choices:
+    - Another person
+    - A sole proprietor (a business that is not a corporation, but is owned by one person)
+    - A partnership (a business that is not a corporation, but is owned by two or more people)
+    - A corporation
+    - None of these apply
+  - note: |
+      You can only use this tool to prepare small claims forms if you are filing the claim for yourself or for certain other people or businesses.
+  
+      If you think you made a mistake:
+      
+      * change your answer above and/or 
+      * tap **Undo** if you're filing for yourself as an individual. 
+      
+      Otherwise, return to [Michigan Legal Help](https://michiganlegalhelp.org) for other legal resources.
+    js show if: |
+      val('Who_are_you_filing_claim_for') == "None of these apply"
+validation code: |
+  if Who_are_you_filing_claim_for == "None of these apply":
+    validation_error("You can only continue if you are filing this claim for yourself or for one of the options below.")
 ---
 id: Who_you_filing
 question: |
@@ -1146,6 +1093,7 @@ subject: Learn more.
 content: |
   If a person is unable to represent themselves in court, someone else might be able to do it for that person. A guardian is appointed by a probate court to make personal decisions for someone. These include day-to-day decisions, such as those involving health care and education. A conservator is appointed by a probate court to care for the personal property and finances of a person. A next friend is a concerned person, usually a relative, appointed by a court who can appear in court for a child or incapacitated adult.
 ---
+if: Who_are_you_filing_claim_for == "A sole proprietor (a business that is not a corporation, but is owned by one person)" or Who_are_you_filing_claim_for == "A partnership (a business that is not a corporation, but is owned by two or more people)"
 id: is_owner_or_partner
 question: |
   % if Who_are_you_filing_claim_for == "A sole proprietor (a business that is not a corporation, but is owned by one person)":
@@ -1235,6 +1183,7 @@ fields:
   - code: |
       users[0].address_fields(country_code=AL_DEFAULT_COUNTRY, default_state=AL_DEFAULT_STATE, show_country=False)
 ---
+if: ((Who_are_you_filing_claim_for == "A sole proprietor (a business that is not a corporation, but is owned by one person)" or Who_are_you_filing_claim_for == "A partnership (a business that is not a corporation, but is owned by two or more people)") and not is_owner_or_partner) or Who_are_you_filing_claim_for == "A corporation"
 id: fulltime_salaried_employee
 question: |
   Authorization
@@ -1382,7 +1331,7 @@ attachment:
       - "has_i_am_the_plaintiff": |
           % if filing_as_individual:
           ${ True }
-          % elif (not filing_as_individual) and (Who_are_you_filing_claim_for=='Another person' and has_court_appointed_you_as):
+          % elif (not filing_as_individual) and ((Who_are_you_filing_claim_for=='Another person' and has_court_appointed_you_as) or (Who_are_you_filing_claim_for=='A sole proprietor (a business that is not a corporation, but is owned by one person)' and is_owner_or_partner)):
           ${ True }
           % else:
           ${ False }

--- a/docassemble/SmallClClaimAndAffidavit/data/questions/final__dc_84_affidavit_and_claim_sm.yml
+++ b/docassemble/SmallClClaimAndAffidavit/data/questions/final__dc_84_affidavit_and_claim_sm.yml
@@ -248,18 +248,6 @@ code: |
     other_plaintiff_kickout
 
   review_other_kickout = True
-# ---
-# code: |
-#   if is_lawyer_representing:
-#     existing_case_kickout
-# 
-#   review_lawyer_kickout = True
-# ---
-# code: |
-#   if want_to_have_jury_trial:
-#     existing_case_kickout
-# 
-#   review_jury_trial_kickout = True
 ---
 code: |
   if claims_suit_against_state:
@@ -652,6 +640,7 @@ content: |
 
   If you are not sure whether your case involves intentional wrongdoing, you may want to talk to a lawyer. You can use the [Guide to Legal Help](https://michiganlegalhelp.org/guide-to-legal-help) to find a lawyer or a legal services office in your area.
 ---
+if: claim_for_damages
 id: claim_for_damages_yes
 question: |
   Cases in which someone caused harm on purpose cannot usually be filed in small claims court.

--- a/docassemble/SmallClClaimAndAffidavit/data/questions/final__dc_84_affidavit_and_claim_sm.yml
+++ b/docassemble/SmallClClaimAndAffidavit/data/questions/final__dc_84_affidavit_and_claim_sm.yml
@@ -82,72 +82,24 @@ code: |
       if not has_court_appointed_you_as:
         has_court_appointed_you_as_kick_out
     else:
-      interview_order_business_or_other
+      if (Who_are_you_filing_claim_for == "A sole proprietor (a business that is not a corporation, but is owned by one person)" or Who_are_you_filing_claim_for == "A partnership (a business that is not a corporation, but is owned by two or more people)"):
+        if not is_owner_or_partner:
+          fulltime_salaried_employee
+          if not fulltime_salaried_employee:
+            fulltime_salaried_employee_kick_out
+    
+      if Who_are_you_filing_claim_for == "A corporation":
+        fulltime_salaried_employee
+        if not fulltime_salaried_employee:
+            fulltime_salaried_employee_kick_out
+    
+      if Who_are_you_filing_claim_for == "Other":
+        other_plaintiff_kickout
+  
   users[0].name.first
   users[0].address.address
   users[0].no_phone_number
 
-  ### ensure user can continue with interview ###
-  interview_order_claim_qualifiers
-
-  ### gather defendant info ###
-  nav.set_section('signpost_other_info')
-  defendant_information
-  defendant_is
-  defendants[0].name.first
-  defendants[0].address.address
-  defendants[0].phone_number
-  if defendant_is == "An individual":
-    is_mentally_competent
-    age_years_or_older
-    military_service
-  
-  ### gather case info ###
-  nav.set_section('signpost_case_info')
-  where_should_file_claim
-  Small_claims_cases_info
-  county_choice
-  court_index
-  the_court
-  if past_or_current_court_case:
-    if about_same_thing_as_this_case:
-      is_the_case_over
-      if not case_filed_in_same_court:
-        what_court_was_case_in
-      if know_case_number_of_the_other_case:
-        case_number
-      judge
-  amount
-  reasons_for_your_claim
-  list_all_dates
-  
-  ### user signature warning, outro, and download screen ###
-  nav.set_section('signpost_download')
-  sign_your_claim
-  MLH_outro_filing_information
-  MLH_outro_saving_answers
-  MLH_download
----
-id: interview_order_business_or_other
-code: |
-  if (Who_are_you_filing_claim_for == "A sole proprietor (a business that is not a corporation, but is owned by one person)" or Who_are_you_filing_claim_for == "A partnership (a business that is not a corporation, but is owned by two or more people)"):
-    if not is_owner_or_partner:
-      fulltime_salaried_employee
-      if not fulltime_salaried_employee:
-        fulltime_salaried_employee_kick_out
-
-  if Who_are_you_filing_claim_for == "A corporation":
-    fulltime_salaried_employee
-    if not fulltime_salaried_employee:
-        fulltime_salaried_employee_kick_out
-
-  if Who_are_you_filing_claim_for == "Other":
-    other_plaintiff_kickout
-
-  interview_order_business_or_other = True
----
-id: interview_order_claim_qualifiers
-code: |
   ### kickouts for lawyer or jury trial ###
   if is_lawyer_representing:
     existing_case_kickout
@@ -189,7 +141,43 @@ code: |
   if not directly_involved_transaction_or_dispute:
     claims_kick_out
 
-  interview_order_claim_qualifiers = True
+  ### gather defendant info ###
+  nav.set_section('signpost_other_info')
+  defendant_information
+  defendant_is
+  defendants[0].name.first
+  defendants[0].address.address
+  defendants[0].phone_number
+  if defendant_is == "An individual":
+    is_mentally_competent
+    age_years_or_older
+    military_service
+  
+  ### gather case info ###
+  nav.set_section('signpost_case_info')
+  where_should_file_claim
+  Small_claims_cases_info
+  county_choice
+  court_index
+  the_court
+  if past_or_current_court_case:
+    if about_same_thing_as_this_case:
+      is_the_case_over
+      if not case_filed_in_same_court:
+        what_court_was_case_in
+      if know_case_number_of_the_other_case:
+        case_number
+      judge
+  amount
+  reasons_for_your_claim
+  list_all_dates
+  
+  ### user signature warning, outro, and download screen ###
+  nav.set_section('signpost_download')
+  sign_your_claim
+  MLH_outro_filing_information
+  MLH_outro_saving_answers
+  MLH_download
 ---
 code: |
   undefine('users[0].name.first')
@@ -260,25 +248,18 @@ code: |
     other_plaintiff_kickout
 
   review_other_kickout = True
----
-code: |
-  if is_lawyer_representing:
-    existing_case_kickout
-
-  review_lawyer_kickout = True
----
-code: |
-  if want_to_have_jury_trial:
-    existing_case_kickout
-
-  review_jury_trial_kickout = True
----
-code: |
-  if claim_for_damages:
-    if not claim_for_damages_yes:
-      claim_for_damages_yes_kickout
-
-  review_damages_claim_kickout = True
+# ---
+# code: |
+#   if is_lawyer_representing:
+#     existing_case_kickout
+# 
+#   review_lawyer_kickout = True
+# ---
+# code: |
+#   if want_to_have_jury_trial:
+#     existing_case_kickout
+# 
+#   review_jury_trial_kickout = True
 ---
 code: |
   if claims_suit_against_state:
@@ -671,7 +652,6 @@ content: |
 
   If you are not sure whether your case involves intentional wrongdoing, you may want to talk to a lawyer. You can use the [Guide to Legal Help](https://michiganlegalhelp.org/guide-to-legal-help) to find a lawyer or a legal services office in your area.
 ---
-if: claim_for_damages
 id: claim_for_damages_yes
 question: |
   Cases in which someone caused harm on purpose cannot usually be filed in small claims court.

--- a/docassemble/SmallClClaimAndAffidavit/data/questions/review.yml
+++ b/docassemble/SmallClClaimAndAffidavit/data/questions/review.yml
@@ -55,6 +55,10 @@ review:
         % elif Who_are_you_filing_claim_for == "A corporation":
         A corporation
         % endif
+
+        **Plaintiff's name:** 
+        
+        ${ users[0].name_full() }
         
         % if Who_are_you_filing_claim_for == "A sole proprietor (a business that is not a corporation, but is owned by one person)" or Who_are_you_filing_claim_for == "A partnership (a business that is not a corporation, but is owned by two or more people)":
         % if Who_are_you_filing_claim_for == "A sole proprietor (a business that is not a corporation, but is owned by one person)":
@@ -78,12 +82,6 @@ review:
         ${ word(yesno(fulltime_salaried_employee)) }
         % endif
     show if: (not filing_as_individual) and defined('Who_are_you_filing_claim_for')
-  - Edit: 
-        - users[0].name.first
-    button: |-
-        **Who is the Plaintiff?** 
-        
-        ${ users[0].name_full() }
   - Edit: 
         - users[0].address.address
     button: |-

--- a/docassemble/SmallClClaimAndAffidavit/data/questions/review.yml
+++ b/docassemble/SmallClClaimAndAffidavit/data/questions/review.yml
@@ -171,8 +171,6 @@ review:
     show if: defined('is_lawyer_representing')
   - Edit: 
       - is_lawyer_representing
-      - recompute:
-        - review_lawyer_kickout
     button: |-
       % if filing_as_individual:
       **Do you have a lawyer?**
@@ -183,8 +181,6 @@ review:
       ${ word(yesno(is_lawyer_representing)) }
   - Edit: 
       - want_to_have_jury_trial
-      - recompute:
-        - review_jury_trial_kickout
     button: |-
       % if filing_as_individual:
       **Do you want a jury trial?**
@@ -199,26 +195,6 @@ review:
       **How much money are you asking for?**
 
       ${ currency(amount, symbol=u'$') }
-  - Edit: 
-      - claim_for_damages
-      - follow up:
-        - claim_for_damages_yes
-      - recompute:
-        - review_damages_claim_kickout
-    button: |-
-      % if filing_as_individual:
-      **Is this a claim for damages against someone who harmed you on purpose?**
-      % else:
-      **Is this a claim for damages against someone who harmed ${ users[0].name_full() } on purpose?**
-      % endif
-
-      ${ word(yesno(claim_for_damages)) }
-
-      % if claim_for_damages:
-      **Does your claim involve an exception for cases dealing with intentional harm?**
-
-      ${ word(yesno(claim_for_damages_yes)) }
-      % endif
   - Edit: 
       - claims_suit_against_state
       - recompute:

--- a/docassemble/SmallClClaimAndAffidavit/data/questions/review.yml
+++ b/docassemble/SmallClClaimAndAffidavit/data/questions/review.yml
@@ -196,6 +196,21 @@ review:
 
       ${ currency(amount, symbol=u'$') }
   - Edit: 
+      - claim_for_damages
+      - follow up:
+        - claim_for_damages_yes
+    button: |-
+      % if filing_as_individual:
+      **Is this a claim for damages against someone who harmed you on purpose?**
+      % else:
+      **Is this a claim for damages against someone who harmed ${ users[0].name_full() } on purpose?**
+      % endif
+      ${ word(yesno(claim_for_damages)) }
+      % if claim_for_damages:
+      **Does your claim involve an exception for cases dealing with intentional harm?**
+      ${ word(yesno(claim_for_damages_yes)) }
+      % endif
+  - Edit: 
       - claims_suit_against_state
       - recompute:
         - review_state_claim_kickout

--- a/docassemble/SmallClClaimAndAffidavit/data/questions/review.yml
+++ b/docassemble/SmallClClaimAndAffidavit/data/questions/review.yml
@@ -205,9 +205,12 @@ review:
       % else:
       **Is this a claim for damages against someone who harmed ${ users[0].name_full() } on purpose?**
       % endif
+      
       ${ word(yesno(claim_for_damages)) }
+      
       % if claim_for_damages:
       **Does your claim involve an exception for cases dealing with intentional harm?**
+      
       ${ word(yesno(claim_for_damages_yes)) }
       % endif
   - Edit: 

--- a/docassemble/SmallClClaimAndAffidavit/data/questions/review.yml
+++ b/docassemble/SmallClClaimAndAffidavit/data/questions/review.yml
@@ -34,14 +34,15 @@ review:
   - Edit: 
       - Who_are_you_filing_claim_for
       - recompute:
-        - review_other_kickout
         - reset_another_person_name
         - users[0].name.first
         - reset_owner_or_partner
         - reset_fulltime_employee
         - regather_owner_partner
-        - regather_fulltime_employee
         - reset_next_friend_appointment
+      - follow up:
+        - is_owner_or_partner
+        - fulltime_salaried_employee
     button: |-
         **What type of party are you filing this claim for?**
         
@@ -54,35 +55,29 @@ review:
         % elif Who_are_you_filing_claim_for == "A corporation":
         A corporation
         % endif
+        
+        % if Who_are_you_filing_claim_for == "A sole proprietor (a business that is not a corporation, but is owned by one person)" or Who_are_you_filing_claim_for == "A partnership (a business that is not a corporation, but is owned by two or more people)":
+        % if Who_are_you_filing_claim_for == "A sole proprietor (a business that is not a corporation, but is owned by one person)":
+        **Are you the owner?**
+        % elif Who_are_you_filing_claim_for == "A partnership (a business that is not a corporation, but is owned by two or more people)":
+        **Are you one of the partners?**
+        % endif 
+
+        ${ word(yesno(is_owner_or_partner)) }
+        % endif
+    
+        % if ((Who_are_you_filing_claim_for == "A sole proprietor (a business that is not a corporation, but is owned by one person)" or Who_are_you_filing_claim_for == "A partnership (a business that is not a corporation, but is owned by two or more people)") and not is_owner_or_partner) or Who_are_you_filing_claim_for == "A corporation":
+        % if Who_are_you_filing_claim_for == "A sole proprietor (a business that is not a corporation, but is owned by one person)":
+        **Are you a full-time salaried employee of the owner and do you know about the facts in the claim?**
+        % elif Who_are_you_filing_claim_for == "A partnership (a business that is not a corporation, but is owned by two or more people)":
+        **Are you a full-time salaried employee of the partnership and do you know about the facts in the claim?**
+        % elif Who_are_you_filing_claim_for == "A corporation":
+        **Are you a full-time salaried employee of the corporation and do you know about the facts in the claim?**
+        % endif
+
+        ${ word(yesno(fulltime_salaried_employee)) }
+        % endif
     show if: (not filing_as_individual) and defined('Who_are_you_filing_claim_for')
-  - Edit: 
-      - is_owner_or_partner
-      - recompute:
-        - regather_fulltime_employee
-    button: |-
-     % if Who_are_you_filing_claim_for == "A sole proprietor (a business that is not a corporation, but is owned by one person)":
-      **Are you the owner?**
-      % elif Who_are_you_filing_claim_for == "A partnership (a business that is not a corporation, but is owned by two or more people)":
-      **Are you one of the partners?**
-      % endif 
-
-      ${ word(yesno(is_owner_or_partner)) }
-    show if: Who_are_you_filing_claim_for == "A sole proprietor (a business that is not a corporation, but is owned by one person)" or Who_are_you_filing_claim_for == "A partnership (a business that is not a corporation, but is owned by two or more people)"
-  - Edit: 
-      - fulltime_salaried_employee
-      - recompute:
-        - review_employee_kickout
-    button: |-
-      % if Who_are_you_filing_claim_for == "A sole proprietor (a business that is not a corporation, but is owned by one person)":
-      **Are you a full-time salaried employee of the owner and do you know about the facts in the claim?**
-      % elif Who_are_you_filing_claim_for == "A partnership (a business that is not a corporation, but is owned by two or more people)":
-      **Are you a full-time salaried employee of the partnership and do you know about the facts in the claim?**
-      % elif Who_are_you_filing_claim_for == "A corporation":
-      **Are you a full-time salaried employee of the corporation and do you know about the facts in the claim?**
-      % endif
-
-      ${ word(yesno(fulltime_salaried_employee)) }
-    show if: ((Who_are_you_filing_claim_for == "A sole proprietor (a business that is not a corporation, but is owned by one person)" or Who_are_you_filing_claim_for == "A partnership (a business that is not a corporation, but is owned by two or more people)") and (not is_owner_or_partner)) or (Who_are_you_filing_claim_for == "A corporation") 
   - Edit: 
         - users[0].name.first
     button: |-
@@ -215,8 +210,6 @@ review:
       % endif
   - Edit: 
       - claims_suit_against_state
-      - recompute:
-        - review_state_claim_kickout
     button: |-
       **Are you filing this case against the State of Michigan or a state agency?**
 
@@ -232,8 +225,6 @@ review:
       ${ word(yesno(claim_against_local_government)) }
   - Edit: 
       - governmental_immunity
-      - recompute:
-        - review_gov_immunity_kickout
     button: |-
       **Does your claim involve one of the following exceptions to government immunity?**
 
@@ -254,8 +245,6 @@ review:
       ${ word(yesno(five_small_claims_cases)) }
   - Edit: 
       - cannot_file_case
-      - recompute:
-        - review_wait_week_kickout
     button: |-
       **Will you wait a week before filing this Affidavit and Claim?**
 
@@ -263,8 +252,6 @@ review:
     show if: five_small_claims_cases
   - Edit: 
       - directly_involved_transaction_or_dispute
-      - recompute:
-        - review_directly_involved_kickout
     button: |-
       **Were you directly involved in the transaction or dispute in this case?**
 


### PR DESCRIPTION
- remove recomputes and lets interview order handle sending to kickout screens
- puts interview order into single block instead of broken up (because it was interfering with review screen functionality described above. Updated setup (without recomputes) works as long as it's all one interview order block, but does not when block is split up like that. As soon as you were no longer inside the same "mini-block" the it no longer would retrigger the kickout screen appropriately.)
- combine some review blocks to avoid logic problems
- fixes checkbox issue with sole proprietorship, fixes apparent misunderstanding from #94 
- "other" plaintiff kickout logic was misbehaving, so changed that to be validation-controlled